### PR TITLE
Feature/components/detail project

### DIFF
--- a/components/projects/modal-detail-project.html
+++ b/components/projects/modal-detail-project.html
@@ -1,0 +1,24 @@
+<div class="projects__modal" id="projects-modal">
+  <div class="projects__modal-overlay" data-modal-close></div>
+  <div class="projects__modal-dialog">
+    <div class="projects__modal-dialog__header">
+      <button class="projects__modal-close" data-modal-close aria-label="Cerrar modal">
+        <span aria-hidden="true">×</span>
+      </button>
+      <p class="projects__modal-title" id="projects__modal-title">Proyecto</p>
+    </div>
+    <div class="projects__modal-viewer">
+      <button class="projects__modal-nav projects__modal-nav--prev" id="projects-modal-prev" aria-label="Anterior imagen">
+        ‹
+      </button>
+      <figure class="projects__modal-stage">
+        <img id="projects__modal-image" />
+      </figure>
+      <button class="projects__modal-nav projects__modal-nav--next" id="projects-modal-next" aria-label="Siguiente imagen">
+        ›
+      </button>
+    </div>
+    <p class="projects__modal-counter" id="projects-modal-counter"></p>
+    <div class="projects__modal-thumbs" id="projects-modal-thumbs"></div>
+  </div>
+</div>

--- a/components/projects/modal-detail-project.html
+++ b/components/projects/modal-detail-project.html
@@ -12,7 +12,7 @@
         ‹
       </button>
       <figure class="projects__modal-stage">
-        <img id="projects__modal-image" />
+        <img id="projects__modal-image" class="projects__modal-image" />
       </figure>
       <button class="projects__modal-nav projects__modal-nav--next" id="projects-modal-next" aria-label="Siguiente imagen">
         ›

--- a/components/projects/projects.html
+++ b/components/projects/projects.html
@@ -46,5 +46,6 @@
 
     <p class="projects__loading" role="status"></p> <!-- Spinner -->
     <div id="card-gallery-projects"></div> <!-- Charge project cards-->
+    <div id="modal-detail-project"></div> <!-- Modal detail -->
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="style/hero/card-hero.css" />
     <link rel="stylesheet" href="style/projects/projects.css" />
     <link rel="stylesheet" href="style/projects/card-gallery-projects.css" />
+    <link rel="stylesheet" href="style/projects/modal-detail-project.css" />
     <link rel="stylesheet" href="style/footer.css" />
     <!-- Social media icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"/>

--- a/js/loadComponents.js
+++ b/js/loadComponents.js
@@ -28,7 +28,9 @@ loadComponent("hero", "components/hero/hero.html", () => {
 /**** PROJECTS ****/
 loadComponent("projects", "components/projects/projects.html", () => {
   loadComponent("card-gallery-projects", "components/projects/card-gallery-projects.html", () => {
-    loadScript("js/projects.js");
+    loadComponent("modal-detail-project", "components/projects/modal-detail-project.html", () => {
+      loadScript("js/projects.js");
+    });
   });
 });
 

--- a/js/projects.js
+++ b/js/projects.js
@@ -108,6 +108,39 @@ function initProjectsModal() {
   let currentIndex = 0;
   const folderCache = new Map();
 
+  const modalStage = section.querySelector(".projects__modal-stage");
+  const canHoverFinePointer =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+  const resetZoomPosition = () => {
+    if (!canHoverFinePointer || !modalStage) return;
+    modalStage.style.setProperty("--zoom-x", "50%");
+    modalStage.style.setProperty("--zoom-y", "50%");
+  };
+
+  const updateZoomPositionFromPointerEvent = (event) => {
+    if (!canHoverFinePointer || !modalStage) return;
+    if (!modal.classList.contains("is-open")) return;
+
+    const rect = modalStage.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+
+    const x = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const y = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+
+    modalStage.style.setProperty("--zoom-x", `${x * 100}%`);
+    modalStage.style.setProperty("--zoom-y", `${y * 100}%`);
+  };
+
+  if (canHoverFinePointer && modalStage) {
+    modalStage.addEventListener("pointerenter", resetZoomPosition);
+    modalStage.addEventListener("pointermove", updateZoomPositionFromPointerEvent);
+    modalStage.addEventListener("pointerleave", resetZoomPosition);
+  }
+
   const FILE_EXTENSIONS = ["jpg", "jpeg", "png", "webp"];
   const MAX_FILES_PER_FOLDER = 40;
 
@@ -124,6 +157,7 @@ function initProjectsModal() {
     modalImage.src = image.src;
     modalImage.alt = image.alt;
     modalCounter.textContent = `${currentIndex + 1} / ${currentImages.length}`;
+    resetZoomPosition();
 
     modalThumbs.querySelectorAll(".projects__modal-thumb, .projects-modal__thumb").forEach((thumb, index) => {
       thumb.classList.toggle("is-active", index === currentIndex);
@@ -210,6 +244,7 @@ function initProjectsModal() {
     modalCounter.textContent = "";
     currentImages = [];
     currentIndex = 0;
+    resetZoomPosition();
 
     if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
       lastFocusedElement.focus();

--- a/js/projects.js
+++ b/js/projects.js
@@ -72,4 +72,241 @@ function initProjectsFilter() {
   setLoading(false);
 }
 
+function initProjectsModal() {
+  const section = document.querySelector("#projects");
+  if (!section || section.dataset.modalReady === "true") return;
+  section.dataset.modalReady = "true";
+
+  const modal = section.querySelector("#projects-modal");
+  const modalImage =
+    section.querySelector("#projects__modal-image") ||
+    section.querySelector("#projects-modal-image");
+  const modalThumbs = section.querySelector("#projects-modal-thumbs");
+  const modalTitle =
+    section.querySelector("#projects__modal-title") ||
+    section.querySelector("#projects-modal-title");
+  const modalCounter = section.querySelector("#projects-modal-counter");
+  const prevButton = section.querySelector("#projects-modal-prev");
+  const nextButton = section.querySelector("#projects-modal-next");
+  const closeTriggers = section.querySelectorAll("[data-modal-close]");
+  const galleriesWrap = section.querySelector("#card-gallery-projects");
+  if (
+    !modal ||
+    !modalImage ||
+    !modalThumbs ||
+    !modalTitle ||
+    !modalCounter ||
+    !prevButton ||
+    !nextButton ||
+    !galleriesWrap
+  ) {
+    return;
+  }
+
+  let lastFocusedElement = null;
+  let currentImages = [];
+  let currentIndex = 0;
+  const folderCache = new Map();
+
+  const FILE_EXTENSIONS = ["jpg", "jpeg", "png", "webp"];
+  const MAX_FILES_PER_FOLDER = 40;
+
+  const setModalState = (open) => {
+    modal.classList.toggle("is-open", open);
+    modal.setAttribute("aria-hidden", String(!open));
+    document.body.classList.toggle("modal-open", open);
+  };
+
+  const renderActiveImage = () => {
+    if (!currentImages.length) return;
+
+    const image = currentImages[currentIndex];
+    modalImage.src = image.src;
+    modalImage.alt = image.alt;
+    modalCounter.textContent = `${currentIndex + 1} / ${currentImages.length}`;
+
+    modalThumbs.querySelectorAll(".projects__modal-thumb, .projects-modal__thumb").forEach((thumb, index) => {
+      thumb.classList.toggle("is-active", index === currentIndex);
+      thumb.setAttribute("aria-current", index === currentIndex ? "true" : "false");
+    });
+  };
+
+  const changeImage = (direction) => {
+    if (!currentImages.length) return;
+    const total = currentImages.length;
+    currentIndex = (currentIndex + direction + total) % total;
+    renderActiveImage();
+  };
+
+  const buildThumbs = () => {
+    modalThumbs.innerHTML = currentImages
+      .map(
+        (image, index) => `
+          <button
+            class="projects__modal-thumb ${index === currentIndex ? "is-active" : ""}"
+            type="button"
+            data-modal-index="${index}"
+            aria-label="Ver imagen ${index + 1}">
+            <img src="${image.src}" alt="${image.alt}" loading="lazy" />
+          </button>
+        `
+      )
+      .join("");
+  };
+
+  const checkImageExists = (src) =>
+    new Promise((resolve) => {
+      const probe = new Image();
+      probe.onload = () => resolve(true);
+      probe.onerror = () => resolve(false);
+      probe.src = src;
+    });
+
+  const loadFolderImages = async (folderPath, title) => {
+    if (folderCache.has(folderPath)) {
+      return folderCache.get(folderPath);
+    }
+
+    const discovered = [];
+    let missesInRow = 0;
+
+    for (let index = 0; index <= MAX_FILES_PER_FOLDER; index += 1) {
+      let foundAtIndex = false;
+
+      for (const ext of FILE_EXTENSIONS) {
+        const src = `${folderPath}/${index}.${ext}`;
+        // eslint-disable-next-line no-await-in-loop
+        const exists = await checkImageExists(src);
+        if (exists) {
+          discovered.push({
+            src,
+            alt: `${title} - imagen ${discovered.length + 1}`
+          });
+          foundAtIndex = true;
+          break;
+        }
+      }
+
+      if (foundAtIndex) {
+        missesInRow = 0;
+      } else {
+        missesInRow += 1;
+      }
+
+      if (discovered.length && missesInRow >= 6) {
+        break;
+      }
+    }
+
+    folderCache.set(folderPath, discovered);
+    return discovered;
+  };
+
+  const closeModal = () => {
+    setModalState(false);
+    modalImage.src = "";
+    modalImage.alt = "";
+    modalThumbs.innerHTML = "";
+    modalCounter.textContent = "";
+    currentImages = [];
+    currentIndex = 0;
+
+    if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
+      lastFocusedElement.focus();
+    }
+  };
+
+  const getFolderPathFromCard = (card) => {
+    const coverSrc = card.querySelector(".gallery__images-cover img")?.getAttribute("src");
+    if (!coverSrc) return null;
+    const lastSlash = coverSrc.lastIndexOf("/");
+    if (lastSlash === -1) return null;
+    return coverSrc.slice(0, lastSlash);
+  };
+
+  const getFallbackImagesFromCard = (card, title) =>
+    Array.from(
+      card.querySelectorAll(".gallery__images-cover img, .gallery__images-more .gallery__thumb > img")
+    )
+      .map((img, index) => ({
+        src: img.getAttribute("src"),
+        alt: img.getAttribute("alt") || `${title} - imagen ${index + 1}`
+      }))
+      .filter((image) => image.src)
+      .filter((image, index, all) => all.findIndex((item) => item.src === image.src) === index);
+
+  const openModalFromCard = async (card) => {
+    const title = card.querySelector(".gallery__info p")?.textContent?.trim() || "Proyecto";
+    const folderPath = getFolderPathFromCard(card);
+    const fallbackImages = getFallbackImagesFromCard(card, title);
+    const folderImages = folderPath ? await loadFolderImages(folderPath, title) : [];
+    const images = folderImages.length ? folderImages : fallbackImages;
+
+    modalTitle.textContent = title;
+    currentImages = images;
+    currentIndex = 0;
+
+    buildThumbs();
+    renderActiveImage();
+
+    lastFocusedElement = document.activeElement;
+    setModalState(true);
+    modal.querySelector(".projects__modal-close, .projects-modal__close")?.focus();
+  };
+
+  galleriesWrap.addEventListener("click", (event) => {
+    if (event.target.closest(".projects__modal-thumb, .projects-modal__thumb")) return;
+    const card = event.target.closest(".gallery");
+    if (!card || !galleriesWrap.contains(card)) return;
+    openModalFromCard(card);
+  });
+
+  galleriesWrap.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const card = event.target.closest(".gallery");
+    if (!card || !galleriesWrap.contains(card)) return;
+    event.preventDefault();
+    openModalFromCard(card);
+  });
+
+  closeTriggers.forEach((trigger) => {
+    trigger.addEventListener("click", closeModal);
+  });
+
+  prevButton.addEventListener("click", () => changeImage(-1));
+  nextButton.addEventListener("click", () => changeImage(1));
+
+  modalThumbs.addEventListener("click", (event) => {
+    const button = event.target.closest(".projects__modal-thumb, .projects-modal__thumb");
+    if (!button) return;
+    const index = Number(button.dataset.modalIndex);
+    if (Number.isNaN(index)) return;
+    currentIndex = index;
+    renderActiveImage();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal.classList.contains("is-open")) {
+      closeModal();
+      return;
+    }
+
+    if (!modal.classList.contains("is-open")) return;
+
+    if (event.key === "ArrowLeft") {
+      changeImage(-1);
+    } else if (event.key === "ArrowRight") {
+      changeImage(1);
+    }
+  });
+
+  galleriesWrap.querySelectorAll(".gallery").forEach((card) => {
+    card.setAttribute("tabindex", "0");
+    card.setAttribute("role", "button");
+    const title = card.querySelector(".gallery__info p")?.textContent?.trim() || "Proyecto";
+    card.setAttribute("aria-label", `Abrir galería de ${title}`);
+  });
+}
+
 initProjectsFilter();
+initProjectsModal();

--- a/style/projects/modal-detail-project.css
+++ b/style/projects/modal-detail-project.css
@@ -72,7 +72,7 @@ body.modal-open {
   overflow: hidden;
   border: 1px solid rgba(57, 57, 56, 0.12);
   background: var(--backgroundCustom);
-  min-height: min(66vh, 620px);
+  height: min(66vh, 620px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -81,10 +81,16 @@ body.modal-open {
 .projects__modal-stage img {
   display: block;
   width: 100%;
-  height: min(66vh);
+  height: 100%;
   object-fit: contain;
+  object-position: center;
   background: var(--black);
+  transform: scale(1);
+  transform-origin: center;
+  transition: transform 220ms ease;
+  will-change: transform;
 }
+
 
 .projects__modal-nav {
   width: 42px;
@@ -138,6 +144,32 @@ body.modal-open {
   display: block;
 }
 
+
+@media (hover: hover) and (pointer: fine) {
+  .projects__modal-stage {
+    --zoom-scale: 1.2;
+    --zoom-x: 50%;
+    --zoom-y: 50%;
+    cursor: zoom-in;
+  }
+
+  .projects__modal-stage:hover {
+    cursor: zoom-out;
+  }
+
+  .projects__modal-stage:hover img {
+    object-fit: cover;
+    object-position: var(--zoom-x) var(--zoom-y);
+    transform: scale(var(--zoom-scale));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .projects__modal-stage img {
+    transition: none;
+  }
+}
+
 @media (max-width: 620px) {
   .projects__modal {
     padding: 12px;
@@ -152,11 +184,11 @@ body.modal-open {
   }
 
   .projects__modal-stage {
-    min-height: 45vh;
+    height: 45vh;
   }
 
   .projects__modal-stage img {
-    height: 45vh;
+    height: 100%;
   }
 
   .projects__modal-nav {

--- a/style/projects/modal-detail-project.css
+++ b/style/projects/modal-detail-project.css
@@ -1,0 +1,176 @@
+body.modal-open {
+  overflow: hidden;
+}
+
+.projects__modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.projects__modal.is-open {
+  display: flex;
+}
+
+.projects__modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(3px);
+}
+
+.projects__modal-dialog {
+  position: relative;
+  width: min(1100px, 96vw);
+  max-height: 80rem;
+  overflow-y: auto;
+  padding: 20px;
+  border-radius: 18px;
+  background: var(--white);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.3);
+}
+
+.projects__modal-dialog__header {
+  display: flex;
+  padding: 10px;
+}
+
+.projects__modal-close {
+  position: sticky;
+  width: 42px;
+  height: 42px;
+  border: 0;
+  border-radius: 50%;
+  background: var(--backgroundCustom);
+  color: var(--greyCustom);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.projects__modal-title {
+  padding: 10px;
+  color: var(--greyCustom);
+  font-family: "ArquitectaBold";
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+.projects__modal-viewer {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.projects__modal-stage {
+  margin: 0;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(57, 57, 56, 0.12);
+  background: var(--backgroundCustom);
+  min-height: min(66vh, 620px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.projects__modal-stage img {
+  display: block;
+  width: 100%;
+  height: min(66vh);
+  object-fit: contain;
+  background: var(--black);
+}
+
+.projects__modal-nav {
+  width: 42px;
+  height: 42px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(57, 57, 56, 0.1);
+  color: var(--greyCustom);
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.projects__modal-counter {
+  margin: 10px 0 0;
+  color: var(--greyCustom);
+  font-family: "ArquitectaBold";
+  font-size: 1rem;
+  text-align: center;
+}
+
+.projects__modal-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+  gap: 8px;
+  margin-top: 12px;
+  justify-content: center;
+}
+
+.projects__modal-thumb {
+  flex: 0 0 90px;
+  border: 2px solid transparent;
+  border-radius: 10px;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  cursor: pointer;
+}
+
+.projects__modal-thumb.is-active {
+  border-color: var(--orangeCustom);
+}
+
+.projects__modal-thumb img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  display: block;
+}
+
+@media (max-width: 620px) {
+  .projects__modal {
+    padding: 12px;
+  }
+
+  .projects__modal-dialog {
+    padding: 14px;
+  }
+
+  .projects__modal-viewer {
+    grid-template-columns: 1fr;
+  }
+
+  .projects__modal-stage {
+    min-height: 45vh;
+  }
+
+  .projects__modal-stage img {
+    height: 45vh;
+  }
+
+  .projects__modal-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 2;
+  }
+
+  .projects__modal-nav--prev {
+    left: 16px;
+  }
+
+  .projects__modal-nav--next {
+    right: 16px;
+  }
+}


### PR DESCRIPTION
Implement modal and auto zoom inside image detail from project selected

💯 Include:

- Open modal with project is selected.
- Count images from the project.
- Show all images from project.
- Expand all width size when users zoom in the image.

🖥️ PC:
<img width="1512" height="982" alt="Captura de pantalla 2026-03-14 a las 15 11 16" src="https://github.com/user-attachments/assets/79549320-3ae9-4657-92ad-a38b5221d941" />

 🔍 Zoom: 
<img width="1512" height="982" alt="Captura de pantalla 2026-03-14 a las 15 11 36" src="https://github.com/user-attachments/assets/eafe0898-544f-4d26-884b-0c04d02ad1a7" />

💻 TABLET:
<img width="748" height="881" alt="Captura de pantalla 2026-03-14 a las 15 12 24" src="https://github.com/user-attachments/assets/b8fee1fa-c046-4dd5-9d10-49d512714374" />

 🔍 Zoom: 
<img width="751" height="871" alt="Captura de pantalla 2026-03-14 a las 15 12 44" src="https://github.com/user-attachments/assets/aa419f21-0eb6-4f88-97a4-a857d8511913" />

📱MOBILE:
<img width="574" height="871" alt="Captura de pantalla 2026-03-14 a las 15 13 26" src="https://github.com/user-attachments/assets/5e24aaee-c3c9-4f4c-8cd4-02708599449d" />

 🔍 Zoom: 
<img width="568" height="868" alt="Captura de pantalla 2026-03-14 a las 15 13 42" src="https://github.com/user-attachments/assets/62ed8c4c-2caa-4887-b13d-630fd9e01641" />


https://github.com/user-attachments/assets/137c3a46-3fd4-4c3a-8661-9fc5bdbf3d78


